### PR TITLE
Display lotto frequencies as table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Codex_fun
 
-Simple repository demonstrating a Lotto analysis app written in R. The app loads the last 50 Lotto draws, displays number frequency and suggests the most likely numbers for the next draw.
+Simple repository demonstrating a Lotto analysis app written in R. The app loads the last 50 Lotto draws, lists number frequencies from most to least common, and suggests the most likely numbers for the next draw.
 
 ## Running
 
-1. Ensure required packages are installed: `shiny`, `httr`, `jsonlite`, `ggplot2`.
+1. Ensure required packages are installed: `shiny`, `httr`, `jsonlite`.
 2. Start the app with:
    ```r
    shiny::runApp()

--- a/app.R
+++ b/app.R
@@ -4,7 +4,6 @@ suppressPackageStartupMessages({
   library(shiny)
   library(httr)
   library(jsonlite)
-  library(ggplot2)
 })
 
 #' Load last 50 lotto results
@@ -47,19 +46,17 @@ lotto_app <- function(data = load_lotto_results()) {
     sidebarLayout(
       sidebarPanel(actionButton("suggest", "Suggest numbers")),
       mainPanel(
-        plotOutput("freqPlot"),
+        tableOutput("freqTable"),
         verbatimTextOutput("suggested")
       )
     )
   )
   server <- function(input, output, session) {
-    output$freqPlot <- renderPlot({
-      df <- data.frame(number = as.integer(names(freq)),
-                       count = as.vector(freq))
-      ggplot(df, aes(number, count)) +
-        geom_col(fill = "steelblue") +
-        theme_minimal() +
-        labs(x = "Number", y = "Frequency")
+    output$freqTable <- renderTable({
+      data.frame(
+        Number = as.integer(names(freq)),
+        Frequency = as.integer(freq)
+      )
     })
     observeEvent(input$suggest, {
       nums <- suggest_numbers(freq)


### PR DESCRIPTION
## Summary
- Replace bar chart with table showing each lotto number and its draw frequency in descending order.
- Update documentation and drop ggplot2 dependency since plotting is no longer used.

## Testing
- `Rscript -e "source('app.R')"` *(fails: command not found)*
- `apt-get install -y r-base` *(stopped due to interactive configuration; R not available)*

------
https://chatgpt.com/codex/tasks/task_e_68b48e0549548333955cb44ba44f7776