### PR TITLE
Allow custom lotto draw count and add frequency chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codex_fun
 
-Simple repository demonstrating a Lotto analysis app written in R. The app loads the last 50 Lotto draws, lists number frequencies from most to least common, and suggests the most likely numbers for the next draw.
+Simple repository demonstrating a Lotto analysis app written in R. The app lets you choose how many recent Lotto draws to analyze, lists number frequencies from most to least common, plots their distribution, and suggests the most likely numbers for the next draw.
 
 ## Running
 
@@ -9,4 +9,4 @@ Simple repository demonstrating a Lotto analysis app written in R. The app loads
    ```r
    shiny::runApp()
    ```
-3. If the online data source is unavailable, the app falls back to the sample data in `data/lotto_last50.csv`.
+3. If the online data source is unavailable, the app falls back to the sample data in `data/lotto_last50.csv` (up to 50 draws).

--- a/app.R
+++ b/app.R
@@ -8,10 +8,10 @@ suppressPackageStartupMessages({
   library(jsonlite)
 })
 
-#' Load last 50 lotto results
+#' Load last lotto results
 #' Attempts to download official data. If that fails, falls back to bundled sample data.
-load_lotto_results <- function() {
-  url <- "https://www.lotto.pl/api/lotteries/draw-results/lotto/last/50"
+load_lotto_results <- function(count = 50) {
+  url <- sprintf("https://www.lotto.pl/api/lotteries/draw-results/lotto/last/%d", count)
   res <- try(httr::GET(url), silent = TRUE)
   if (!inherits(res, "try-error") && httr::status_code(res) == 200) {
     txt <- httr::content(res, as = "text", encoding = "UTF-8")
@@ -26,7 +26,11 @@ load_lotto_results <- function() {
       return(df)
     }
   }
-  read.csv("data/lotto_last50.csv")
+  df <- read.csv("data/lotto_last50.csv")
+  if (count < nrow(df)) {
+    df <- head(df, count)
+  }
+  df
 }
 
 #' Calculate frequency of drawn numbers
@@ -46,27 +50,41 @@ suggest_numbers <- function(freq, n = 6) {
 }
 
 #' Create Shiny application
-lotto_app <- function(data = load_lotto_results()) {
-  freq <- calculate_frequency(data)
+lotto_app <- function() {
   ui <- fluidPage(
     titlePanel("Lotto frequency analyzer"),
     sidebarLayout(
-      sidebarPanel(actionButton("suggest", "Suggest numbers")),
+      sidebarPanel(
+        numericInput("draws", "Number of recent draws", value = 50, min = 1),
+        actionButton("suggest", "Suggest numbers")
+      ),
       mainPanel(
         tableOutput("freqTable"),
+        plotOutput("freqPlot"),
         verbatimTextOutput("suggested")
       )
     )
   )
   server <- function(input, output, session) {
+    data <- reactive(load_lotto_results(input$draws))
+    freq <- reactive(calculate_frequency(data()))
     output$freqTable <- renderTable({
       data.frame(
-        Number = as.integer(names(freq)),
-        Frequency = as.integer(freq)
+        Number = as.integer(names(freq())),
+        Frequency = as.integer(freq())
+      )
+    })
+    output$freqPlot <- renderPlot({
+      barplot(
+        freq(),
+        names.arg = names(freq()),
+        xlab = "Number",
+        ylab = "Frequency",
+        main = paste("Frequency in last", input$draws, "draws")
       )
     })
     observeEvent(input$suggest, {
-      nums <- sort(suggest_numbers(freq))
+      nums <- sort(suggest_numbers(freq()))
       output$suggested <- renderText(
         paste("Suggested numbers:", paste(nums, collapse = ", "))
       )


### PR DESCRIPTION
## Summary
- let users choose how many recent draws to analyze
- plot a bar chart of number frequencies for the chosen draws
- document draw count option and chart in README

## Testing
- `Rscript -e "source('app.R')"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b598f13324833397c74c3c76c75db9