### PR TITLE
Display number frequencies via clickable list

### DIFF
--- a/app.R
+++ b/app.R
@@ -53,17 +53,26 @@ lotto_app <- function(data = load_lotto_results()) {
     sidebarLayout(
       sidebarPanel(actionButton("suggest", "Suggest numbers")),
       mainPanel(
-        tableOutput("freqTable"),
+        uiOutput("numberList"),
+        verbatimTextOutput("freqText"),
         verbatimTextOutput("suggested")
       )
     )
   )
   server <- function(input, output, session) {
-    output$freqTable <- renderTable({
-      data.frame(
-        Number = as.integer(names(freq)),
-        Frequency = as.integer(freq)
-      )
+    numbers <- 1:49
+    output$numberList <- renderUI({
+      tagList(lapply(numbers, function(i) {
+        actionLink(paste0("num_", i), label = i, style = "margin:4px;")
+      }))
+    })
+    output$freqText <- renderText("Click a number to see its frequency")
+    lapply(numbers, function(i) {
+      observeEvent(input[[paste0("num_", i)]], {
+        f <- freq[as.character(i)]
+        if (is.na(f)) f <- 0
+        output$freqText <- renderText(paste("Frequency of", i, ":", f))
+      })
     })
     observeEvent(input$suggest, {
       nums <- sort(suggest_numbers(freq))


### PR DESCRIPTION
## Summary
- Replace frequency table with clickable list of numbers.
- Show selected number's frequency when clicked.
- Keep suggested numbers feature intact.

## Testing
- `apt-get update` *(fails: repository not signed)*
- `Rscript app.R` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b59874d1ec8333aa3c94f0ae42afa6